### PR TITLE
Add support for supplying input arguments for ktlint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## Ktlint PR comments v1.1
+# Ktlint PR comments v1.1
 
 This action runs [ktlint](https://ktlint.github.io/) against all `.kt` files that were changed in a PR
 and makes a line comment for every error that ktlint found.
@@ -11,16 +11,17 @@ Note that in order to make a comment the error must be in a line that is part of
 - uses: le0nidas/ktlint-pr-comments@v1.1
   with:
     repotoken: ${{ secrets.GITHUB_TOKEN }}
-    disabledrules: "parameter-list-wrapping,final-newline"
+    arguments: "--disabled_rules=parameter-list-wrapping,final-newline"
 ```
 
 ## Example
 
 The code:
+
 ```kotlin
 class Person(val name: String, val age: Int) {
 }
-``` 
+```
 
 will produce the comment:
 

--- a/action.yml
+++ b/action.yml
@@ -16,6 +16,6 @@ inputs:
     description: A token that grands access to read/write actions. Usually secrets.GITHUB_TOKEN.
     required: true
 
-  disabledrules:
-    description: Comma separated list of rules to disable
+  arguments:
+    description: Arguments to pass to ktlint. Note you cannot set your own --reporter argument, it will be ignored
     required: false

--- a/image/run-scripts.sh
+++ b/image/run-scripts.sh
@@ -28,9 +28,10 @@ echo '------------------------'
 echo ''
 
 
-echo 'Running ktlint...'
 # Strip out any --reporter arguments supplied by the user
-INPUT_ARGUMENTS = $INPUT_ARGUMENTS#--reporter*[[:space:]]
+INPUT_ARGUMENTS=${INPUT_ARGUMENTS/--reporter*[[:space:]]/}
+
+echo 'Running ktlint...'
 echo "::debug::$COLLECTION_REPORT=$(cat $COLLECTION_REPORT)"
 ./ktlint $(cat $COLLECTION_REPORT | awk 'BEGIN { ORS=" " }; {print $1}') --reporter=json,output=$KTLINT_REPORT $INPUT_ARGUMENTS
 

--- a/image/run-scripts.sh
+++ b/image/run-scripts.sh
@@ -30,10 +30,11 @@ echo ''
 
 # Strip out any --reporter arguments supplied by the user
 INPUT_ARGUMENTS=${INPUT_ARGUMENTS/--reporter*[[:space:]]/}
+echo "::debug::INPUT_ARGUMENTS=$INPUT_ARGUMENTS"
 
 echo 'Running ktlint...'
 echo "::debug::$COLLECTION_REPORT=$(cat $COLLECTION_REPORT)"
-./ktlint $(cat $COLLECTION_REPORT | awk 'BEGIN { ORS=" " }; {print $1}') --reporter=json,output=$KTLINT_REPORT $INPUT_ARGUMENTS
+./ktlint $(cat $COLLECTION_REPORT | awk 'BEGIN { ORS=" " }; {print $1}') --reporter=json,output=$KTLINT_REPORT
 
 echo "::debug::$KTLINT_REPORT=$(cat $KTLINT_REPORT)"
 

--- a/image/run-scripts.sh
+++ b/image/run-scripts.sh
@@ -34,7 +34,7 @@ echo "::debug::INPUT_ARGUMENTS=$INPUT_ARGUMENTS"
 
 echo 'Running ktlint...'
 echo "::debug::$COLLECTION_REPORT=$(cat $COLLECTION_REPORT)"
-./ktlint $(cat $COLLECTION_REPORT | awk 'BEGIN { ORS=" " }; {print $1}') --reporter=json,output=$KTLINT_REPORT
+./ktlint $(cat $COLLECTION_REPORT | awk 'BEGIN { ORS=" " }; {print $1}') --reporter=json,output=$KTLINT_REPORT $INPUT_ARGUMENTS
 
 echo "::debug::$KTLINT_REPORT=$(cat $KTLINT_REPORT)"
 

--- a/image/run-scripts.sh
+++ b/image/run-scripts.sh
@@ -29,8 +29,10 @@ echo ''
 
 
 echo 'Running ktlint...'
+# Strip out any --reporter arguments supplied by the user
+INPUT_ARGUMENTS = $INPUT_ARGUMENTS#--reporter*[[:space:]]
 echo "::debug::$COLLECTION_REPORT=$(cat $COLLECTION_REPORT)"
-./ktlint $(cat $COLLECTION_REPORT | awk 'BEGIN { ORS=" " }; {print $1}') --reporter=json,output=$KTLINT_REPORT --disabled_rules=$INPUT_DISABLEDRULES
+./ktlint $(cat $COLLECTION_REPORT | awk 'BEGIN { ORS=" " }; {print $1}') --reporter=json,output=$KTLINT_REPORT $INPUT_ARGUMENTS
 
 echo "::debug::$KTLINT_REPORT=$(cat $KTLINT_REPORT)"
 


### PR DESCRIPTION
I was meant to open this as a draft for now so I can test this implementation. Probably a good idea to not merge until I can test it
User-supplied --reporter argument should be filtered out automatically.
Resolves #8 